### PR TITLE
Add custom Meshtastic theme

### DIFF
--- a/docs/static/styles/extra.css
+++ b/docs/static/styles/extra.css
@@ -1,0 +1,35 @@
+/* Custom Palette for Meshtastic */
+:root * {
+  /* Meshtastic theme colors */
+  --mt-primary-color: #67EA94;
+  --mt-primary-color--transparent: #67EA9488;
+  --mt-secondary-color: #2C2D3C;
+
+  /* Primary colors */
+  --md-primary-fg-color:               var(--mt-primary-color);
+  --md-primary-fg-color--light:        var(--mt-primary-color);
+  --md-primary-fg-color--dark:         var(--mt-primary-color);
+  --md-primary-bg-color:               var(--mt-secondary-color);
+  --md-primary-bg-color--light:        var(--mt-secondary-color);
+
+  /* Accent colors */
+  --md-accent-fg-color:                var(--mt-primary-color);
+  --md-accent-fg-color--transparent:   var(--mt-primary-color--transparent);
+  --md-accent-bg-color:                var(--mt-secondary-color);
+  --md-accent-bg-color--light:         var(--mt-secondary-color);
+
+  /* General color changes */
+  --md-default-bg-color:               #1B1B1D;
+  --md-default-fg-color--light:        #FFFFFF;
+  --md-typeset-a-color:                var(--mt-primary-color);
+}
+
+/* Add slight border radius to images */
+img {
+  border-radius: 0.25rem;
+}
+
+/* Show underline on links when hovered */
+.md-content a:hover {
+  text-decoration: underline;
+}

--- a/docs/static/styles/extra.css
+++ b/docs/static/styles/extra.css
@@ -1,35 +1,35 @@
 /* Custom Palette for Meshtastic */
 :root * {
-  /* Meshtastic theme colors */
-  --mt-primary-color: #67EA94;
-  --mt-primary-color--transparent: #67EA9488;
-  --mt-secondary-color: #2C2D3C;
+	/* Meshtastic theme colors */
+	--mt-primary-color: #67EA94;
+	--mt-primary-color--transparent: #67EA9488;
+	--mt-secondary-color: #2C2D3C;
 
-  /* Primary colors */
-  --md-primary-fg-color:               var(--mt-primary-color);
-  --md-primary-fg-color--light:        var(--mt-primary-color);
-  --md-primary-fg-color--dark:         var(--mt-primary-color);
-  --md-primary-bg-color:               var(--mt-secondary-color);
-  --md-primary-bg-color--light:        var(--mt-secondary-color);
+	/* Primary colors */
+	--md-primary-fg-color: var(--mt-primary-color);
+	--md-primary-fg-color--light: var(--mt-primary-color);
+	--md-primary-fg-color--dark: var(--mt-primary-color);
+	--md-primary-bg-color: var(--mt-secondary-color);
+	--md-primary-bg-color--light: var(--mt-secondary-color);
 
-  /* Accent colors */
-  --md-accent-fg-color:                var(--mt-primary-color);
-  --md-accent-fg-color--transparent:   var(--mt-primary-color--transparent);
-  --md-accent-bg-color:                var(--mt-secondary-color);
-  --md-accent-bg-color--light:         var(--mt-secondary-color);
+	/* Accent colors */
+	--md-accent-fg-color: var(--mt-primary-color);
+	--md-accent-fg-color--transparent: var(--mt-primary-color--transparent);
+	--md-accent-bg-color: var(--mt-secondary-color);
+	--md-accent-bg-color--light: var(--mt-secondary-color);
 
-  /* General color changes */
-  --md-default-bg-color:               #1B1B1D;
-  --md-default-fg-color--light:        #FFFFFF;
-  --md-typeset-a-color:                var(--mt-primary-color);
+	/* General color changes */
+	--md-default-bg-color: #1B1B1D;
+	--md-default-fg-color--light: #FFFFFF;
+	--md-typeset-a-color: var(--mt-primary-color);
 }
 
 /* Add slight border radius to images */
 img {
-  border-radius: 0.25rem;
+	border-radius: 0.25rem;
 }
 
 /* Show underline on links when hovered */
 .md-content a:hover {
-  text-decoration: underline;
+	text-decoration: underline;
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,9 +60,16 @@ theme:
     - content.action.view
     - content.action.edit
 
+  # We implement a custom Meshtastic palette, but use `slate` as a base
+  palette:
+    scheme: slate
+
 extra:
   social:
     - icon: fontawesome/brands/discord 
       link: https://discord.gg/4WN32RHGSs
     - icon: fontawesome/brands/github 
       link: https://github.com/mtnmesh
+
+extra_css:
+  - static/styles/extra.css

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,7 @@ copyright: © Creative Commons Attribution-ShareAlike 4.0 International License
 site_url: https://mtnme.sh/
 repo_url: https://github.com/MtnMesh/mtnmesh.github.io
 edit_uri: edit/main/docs/
+
 nav:
   - Home: index.md
   - About: about.md
@@ -59,9 +60,8 @@ theme:
     - toc.integrate
     - content.action.view
     - content.action.edit
-
-  # We implement a custom Meshtastic palette, but use `slate` as a base
   palette:
+    # The custom Meshtastic theme uses `slate` as a base
     scheme: slate
 
 extra:
@@ -72,4 +72,5 @@ extra:
       link: https://github.com/mtnmesh
 
 extra_css:
+  # Custom styles for Meshtastic theme
   - static/styles/extra.css


### PR DESCRIPTION
This pull request introduces a custom Meshtastic theme to the site. The most important changes include defining custom CSS variables for the theme, enabling a base color scheme, and linking the new stylesheet.

### Changes:

* [`docs/static/styles/extra.css`](diffhunk://#diff-781cd1537e1e032b7b2eff63ebc948c3f7a0cb2f4184ba2479fa9c650cb9408fR1-R35): Added custom CSS variables for the Meshtastic theme, including primary, secondary, and accent colors, as well as general style tweaks like border radii for images and hover underlines for links.
* [`mkdocs.yml`](diffhunk://#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2R63-R76): Configured the theme to use the `slate` base scheme and linked the custom stylesheet (`extra.css`).
